### PR TITLE
Enable metric variable exclusion per component scope

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigConstants.java
@@ -1248,6 +1248,12 @@ public final class ConfigConstants {
 
 	/** The set of variables that should be excluded. */
 	public static final String METRICS_REPORTER_EXCLUDED_VARIABLES = "scope.variables.excludes";
+	public static final String METRICS_REPORTER_JM_EXCLUDED_VARIABLES = "scope.jm.variables.excludes";
+	public static final String METRICS_REPORTER_JM_JOB_EXCLUDED_VARIABLES = "scope.jm.job.variables.excludes";
+	public static final String METRICS_REPORTER_TM_EXCLUDED_VARIABLES = "scope.tm.variables.excludes";
+	public static final String METRICS_REPORTER_TM_JOB_EXCLUDED_VARIABLES = "scope.tm.job.variables.excludes";
+	public static final String METRICS_REPORTER_TASK_EXCLUDED_VARIABLES = "scope.task.variables.excludes";
+	public static final String METRICS_REPORTER_OPERATOR_EXCLUDED_VARIABLES = "scope.operator.variables.excludes";
 
 	/** @deprecated Use {@link MetricOptions#SCOPE_DELIMITER} instead. */
 	@Deprecated

--- a/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
+++ b/flink-metrics/flink-metrics-jmx/src/test/java/org/apache/flink/metrics/jmx/JMXReporterTest.java
@@ -306,6 +306,6 @@ public class JMXReporterTest extends TestLogger {
 	}
 
 	private static ReporterScopedSettings createReporterScopedSettings(int reporterIndex) {
-		return new ReporterScopedSettings(reporterIndex, ',', Collections.emptySet());
+		return new ReporterScopedSettings(reporterIndex, ',', Collections.emptySet(), Collections.emptyMap());
 	}
 }

--- a/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
+++ b/flink-metrics/flink-metrics-prometheus/src/test/java/org/apache/flink/metrics/prometheus/PrometheusReporterTest.java
@@ -347,6 +347,6 @@ public class PrometheusReporterTest extends TestLogger {
 	}
 
 	private static ReporterScopedSettings createReporterScopedSettings() {
-		return new ReporterScopedSettings(0, ',', Collections.emptySet());
+		return new ReporterScopedSettings(0, ',', Collections.emptySet(), Collections.emptyMap());
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricRegistryImpl.java
@@ -157,7 +157,8 @@ public class MetricRegistryImpl implements MetricRegistry {
 						new ReporterScopedSettings(
 							reporters.size(),
 							delimiterForReporter.charAt(0),
-							reporterSetup.getExcludedVariables())));
+							reporterSetup.getExcludedVariables(),
+							reporterSetup.getExcludedComponentVariables())));
 				}
 				catch (Throwable t) {
 					LOG.error("Could not instantiate metrics reporter {}. Metrics might not be exposed/reported.", namedReporter, t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/AbstractMetricGroup.java
@@ -29,6 +29,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import org.slf4j.Logger;
@@ -495,6 +496,17 @@ public abstract class AbstractMetricGroup<A extends AbstractMetricGroup<?>> impl
 			default:
 				return new GenericMetricGroup(registry, this, name);
 		}
+	}
+
+	/**
+	 * Return component scope for this metric group
+	 * @return enum value of ComponentScope
+	 */
+	public ComponentScope getComponentScope() {
+		if (parent != null) {
+			return parent.getComponentScope();
+		}
+		return null;
 	}
 
 	/**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/FrontMetricGroup.java
@@ -19,8 +19,12 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Metric group which forwards all registration calls to a variable parent metric group that injects a variable reporter
@@ -51,7 +55,13 @@ public class FrontMetricGroup<P extends AbstractMetricGroup<?>> extends ProxyMet
 
 	@Override
 	public Map<String, String> getAllVariables() {
-		return parentMetricGroup.getAllVariables(this.settings.getReporterIndex(), this.settings.getExcludedVariables());
+		ComponentScope scope = parentMetricGroup.getComponentScope();
+		Set<String> excludedVariables = new HashSet<>();
+		excludedVariables.addAll(this.settings.getExcludedVariables());
+		if (scope != null) {
+			excludedVariables.addAll(this.settings.getExcludedComponentVariables().getOrDefault(scope, Collections.emptySet()));
+		}
+		return parentMetricGroup.getAllVariables(this.settings.getReporterIndex(), excludedVariables);
 	}
 
 	public String getLogicalScope(CharacterFilter filter) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.metrics.groups;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 
 import javax.annotation.Nullable;
 
@@ -53,5 +54,10 @@ public class JobManagerJobMetricGroup extends JobMetricGroup<JobManagerMetricGro
 	@Override
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return Collections.emptyList();
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.JOBMANAGER_JOB;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerMetricGroup.java
@@ -23,6 +23,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.HashMap;
@@ -112,6 +113,11 @@ public class JobManagerMetricGroup extends ComponentMetricGroup<JobManagerMetric
 	@Override
 	protected String getGroupName(CharacterFilter filter) {
 		return "jobmanager";
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.JOBMANAGER;
 	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/OperatorMetricGroup.java
@@ -23,6 +23,7 @@ import org.apache.flink.metrics.CharacterFilter;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 
 import java.util.Collections;
@@ -91,5 +92,10 @@ public class OperatorMetricGroup extends ComponentMetricGroup<TaskMetricGroup> {
 	@Override
 	protected String getGroupName(CharacterFilter filter) {
 		return "operator";
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.OPERATROR;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/ReporterScopedSettings.java
@@ -17,8 +17,10 @@
 
 package org.apache.flink.runtime.metrics.groups;
 
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.util.Preconditions;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -32,8 +34,11 @@ public class ReporterScopedSettings {
 
 	private Set<String> excludedVariables;
 
-	public ReporterScopedSettings(int reporterIndex, char delimiter, Set<String> excludedVariables) {
+	private Map<ComponentScope, Set<String>> excludedComponentVariables;
+
+	public ReporterScopedSettings(int reporterIndex, char delimiter, Set<String> excludedVariables, Map<ComponentScope, Set<String>> excludedComponentVariables) {
 		this.excludedVariables = excludedVariables;
+		this.excludedComponentVariables = excludedComponentVariables;
 		Preconditions.checkArgument(reporterIndex >= 0);
 		this.reporterIndex = reporterIndex;
 		this.delimiter = delimiter;
@@ -49,5 +54,9 @@ public class ReporterScopedSettings {
 
 	public Set<String> getExcludedVariables() {
 		return excludedVariables;
+	}
+
+	public Map<ComponentScope, Set<String>> getExcludedComponentVariables() {
+		return excludedComponentVariables;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerJobMetricGroup.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
@@ -121,5 +122,10 @@ public class TaskManagerJobMetricGroup extends JobMetricGroup<TaskManagerMetricG
 	@Override
 	protected Iterable<? extends ComponentMetricGroup> subComponents() {
 		return tasks.values();
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.TASKMANAGER_JOB;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskManagerMetricGroup.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.util.Preconditions;
 
@@ -153,6 +154,11 @@ public class TaskManagerMetricGroup extends ComponentMetricGroup<TaskManagerMetr
 	@Override
 	protected String getGroupName(CharacterFilter filter) {
 		return "taskmanager";
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.TASKMANAGER;
 	}
 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskMetricGroup.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ComponentScope;
 import org.apache.flink.runtime.metrics.scope.ScopeFormat;
 import org.apache.flink.util.AbstractID;
 
@@ -183,5 +184,10 @@ public class TaskMetricGroup extends ComponentMetricGroup<TaskManagerJobMetricGr
 	@Override
 	protected String getGroupName(CharacterFilter filter) {
 		return "task";
+	}
+
+	@Override
+	public ComponentScope getComponentScope() {
+		return ComponentScope.TASK;
 	}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ComponentScope.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ComponentScope.java
@@ -1,0 +1,10 @@
+package org.apache.flink.runtime.metrics.scope;
+
+public enum ComponentScope {
+	JOBMANAGER,
+	JOBMANAGER_JOB,
+	TASKMANAGER,
+	TASKMANAGER_JOB,
+	TASK,
+	OPERATROR
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
